### PR TITLE
Add CI for the ImageWorker

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,0 +1,9 @@
+SmalltalkCISpec {
+  #loading : [
+      SCIMetacelloLoadSpec {
+          #baseline : 'ImageWorker',
+          #directory : 'source',
+          #platforms : [ #pharo ]
+      }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: smalltalk
+sudo: required
+
+os:
+- linux
+
+
+smalltalk:
+- Pharo-7.0
+- Pharo64-7.0
+
+script:
+- $SMALLTALK_CI_HOME/run.sh
+
+after_script:
+ - pip install --user benchupload && python -mbenchupload --dir=$SMALLTALK_CI_BUILD
+


### PR DESCRIPTION
Only support Pharo7.0 or later. The Fuel Metadata can not be loaded on a Pharo6.1 image. And because of the usage of Tonnel we can't support anything older than Pharo 6.1.