### PR TITLE
Copy the sources in addition to the image

### DIFF
--- a/source/ImageWorker/ImageWorker.class.st
+++ b/source/ImageWorker/ImageWorker.class.st
@@ -89,6 +89,17 @@ ImageWorker >> evaluateBlock [
 { #category : #private }
 ImageWorker >> forkImage [
 	self updateSession.
+
+	"Make sure there is an accessible sources file for the new image. Make sure that there
+	is a sources file next to the image if there is currently one next to the image. On Unix
+	systems we could optimize and make a symlink."
+	(Smalltalk sourcesFile isChildOf: Smalltalk imageFile parent asFileReference) ifTrue: [
+		| destSources |
+		destSources := baseFile parent / Smalltalk sourcesFile basename.
+		destSources deleteIfAbsent: [].
+		destSources parent ensureCreateDirectory.
+		Smalltalk sourcesFile copyTo: destSources.
+	].
 	"Trying to avoid running any commandline handlers when running the forked image"
 	Smalltalk backupTo: self baseFile fullName.
 	NonInteractiveTranscript allInstancesDo: [ :each | each initializeStream ].


### PR DESCRIPTION
At least in Pharo7 the sources need to be accessible for it to work. If the sources are located next to the image (in contrast to the VM) we need to copy/link them to the temporary directory. This is necessary for runs with smalltalkCI but should match common deployments as well.

Another option was to avoid creating a temporary directory but then the clean-up is complicated to impossible (which ombus-session must go?).