### PR TITLE
Migrate from squeaksource to GH/dtlewis290/OSProcess-Tonel

### DIFF
--- a/source/BaselineOfImageWorker/BaselineOfImageWorker.class.st
+++ b/source/BaselineOfImageWorker/BaselineOfImageWorker.class.st
@@ -10,30 +10,30 @@ BaselineOfImageWorker >> baseline: spec [
 
 	spec for: #pharo do: [			
 		self 
-			commandShell: spec;
+			osProcess: spec;
 			fuelMetalevel: spec.
 			
 		spec
 			package: 'ImageWorker' with: [ 
-				spec requires: #('CommandShell' 'Fuel')].
+				spec requires: #('OSProcess' 'Fuel')].
 			
 		spec
 			group: 'default' with: #('ImageWorker') ].
 ]
 
-{ #category : #'external projects' }
-BaselineOfImageWorker >> commandShell: spec [
-	spec project: 'CommandShell' with: [
-		spec
-			repository: 'http://www.squeaksource.com/MetacelloRepository';
-			className: 'ConfigurationOfCommandShell';
-			version: #stable ].
-]
-
 { #category : #baselines }
 BaselineOfImageWorker >> fuelMetalevel: spec [
-	spec baseline: 'Fuel' with: [ 
-		spec 
-			repository: 'github://theseion/Fuel:3.0.1/repository';
-			loads: #( 'Fuel-Metalevel' ) ]
+	spec
+		baseline: 'Fuel'
+		with: [
+			spec
+				repository: 'github://theseion/Fuel:3.0.1/repository';
+				loads: #('Fuel-Metalevel') ]
+]
+
+{ #category : #'external projects' }
+BaselineOfImageWorker >> osProcess: spec [
+	spec
+		baseline: 'OSProcess'
+		with: [ spec repository: 'github://dtlewis290/OSProcess-Tonel/src' ]
 ]

--- a/source/BaselineOfImageWorker/BaselineOfImageWorker.class.st
+++ b/source/BaselineOfImageWorker/BaselineOfImageWorker.class.st
@@ -35,5 +35,5 @@ BaselineOfImageWorker >> fuelMetalevel: spec [
 BaselineOfImageWorker >> osProcess: spec [
 	spec
 		baseline: 'OSProcess'
-		with: [ spec repository: 'github://dtlewis290/OSProcess-Tonel/src' ]
+		with: [ spec repository: 'github://dtlewis290/OSProcess-Tonel:56030885fad6b924572260d92f9904df8bb6b502/src' ]
 ]


### PR DESCRIPTION
This change is two-fold: 
1. Directly depend on OSProcess instead of CommandShell (that depends on OSProcess). CommandShell itself was not used so no need to load it.
2. Use the version that was migrated to github. Squeaksource seems to be unstable (at least in last weeks), producing "random" loading errors that are annoying in mongotalk/voyage Travis CI. More info about the migration on "[squeak-dev] OSProcess and CommandShell available on GitHub for Pharo users"

Fixes #4